### PR TITLE
feat: 구독 응답에 이메일 전송 상태 반영

### DIFF
--- a/src/components/SubscribeForm.tsx
+++ b/src/components/SubscribeForm.tsx
@@ -54,25 +54,36 @@ export default function SubscribeForm() {
       if (response.success) {
         const data = response.data;
 
-        // 백엔드에서 반환한 메시지 사용
-        if (data.message) {
-          setMessage({
-            type: data.is_new_subscriber ? "success" : "info",
-            text: data.is_new_subscriber
-              ? `✅ ${data.message}`
-              : `ℹ️ ${data.message}`,
-          });
-        } else {
-          // fallback
-          setMessage({
-            type: "success",
-            text: "✅ 구독이 완료되었습니다! 매일 오전 9시에 리포트를 보내드립니다.",
-          });
-        }
-
-        // 신규 구독자인 경우에만 이메일 필드 초기화
         if (data.is_new_subscriber) {
+          // 신규 구독자
+          if (data.email_sent) {
+            setMessage({
+              type: "success",
+              text: "✅ 구독이 완료되었습니다! 환영 이메일을 확인해주세요.",
+            });
+          } else if (data.email_sent === false) {
+            setMessage({
+              type: "warning",
+              text: "✅ 구독은 완료되었지만, 환영 이메일 전송에 실패했습니다. 리포트는 내일 오전 9시부터 정상 발송됩니다.",
+            });
+          } else {
+            // email_sent가 없는 경우 (이전 버전 호환)
+            setMessage({
+              type: "success",
+              text: data.message
+                ? `✅ ${data.message}`
+                : "✅ 구독이 완료되었습니다! 매일 오전 9시에 리포트를 보내드립니다.",
+            });
+          }
           setEmail("");
+        } else {
+          // 기존 구독자
+          setMessage({
+            type: "info",
+            text: data.message
+              ? `ℹ️ ${data.message}`
+              : "ℹ️ 이미 구독 중인 이메일입니다.",
+          });
         }
       } else {
         setMessage({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -103,6 +103,7 @@ export interface SubscriptionData {
   updated_at: string;
   is_new_subscriber?: boolean; // 신규 구독자 여부
   message?: string; // 응답 메시지
+  email_sent?: boolean; // 환영 이메일 전송 성공 여부
 }
 
 export interface DownloadResponse {


### PR DESCRIPTION
## Summary
- 백엔드 `email_sent` 필드에 따라 구독 시 사용자 피드백 메시지를 분기 처리
- 환영 이메일 전송 실패 시 경고 메시지를 표시하여 사용자에게 명확한 피드백 제공

## Changes
| 파일 | 변경 내용 |
|---|---|
| `src/types/index.ts` | `SubscriptionData`에 `email_sent?: boolean` 필드 추가 |
| `src/components/SubscribeForm.tsx` | `email_sent` 값에 따른 3단계 메시지 분기 |

## Message Logic
| 조건 | 타입 | 메시지 |
|---|---|---|
| 신규 + `email_sent=true` | success | 환영 이메일 확인 안내 |
| 신규 + `email_sent=false` | warning | 구독 완료 + 이메일 실패 경고 |
| 신규 + `email_sent` 없음 | success | 기존 동작 (이전 BE 버전 호환) |
| 기존 구독자 | info | 이미 구독 중 안내 |

## Related
- StockPlay-BE PR #18: fix: 이메일 구독 시 환영 메일 발송 실패 수정
- Closes #21

## Test plan
- [ ] 신규 이메일 구독 → `email_sent=true` 시 성공 메시지 확인
- [ ] 이메일 전송 실패 시 → warning 메시지 표시 확인
- [ ] 기존 구독 이메일 입력 → info 메시지 확인
- [ ] 이전 버전 BE와 호환 (`email_sent` 없는 응답) 확인